### PR TITLE
Fix 2.8 compatibility

### DIFF
--- a/go-web-server/flake.nix
+++ b/go-web-server/flake.nix
@@ -37,7 +37,7 @@
           };
         };
 
-        defaultApp = utils.lib.mkApp { drv = self.packages.${system}.default; };
+        apps.default = utils.lib.mkApp { drv = self.packages.${system}.default; };
 
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [ go gopls gotools go-tools ];


### PR DESCRIPTION
When running  the project with `nix run`, I encountered the error

```sh
$ nix run
error: attribute 'defaultApp.x86_64-linux' should have type 'derivation'
```

This PR should fix it.

This change is similar to https://github.com/Xe/gohello/commit/0850a0ddda5ff08c85ee13d3a1254202549bbde1.